### PR TITLE
Hard coded delay to properly wait for Lavalink to be ready to accept connections

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,6 +48,7 @@ services:
             - ./settings.json:/app/settings.json
         build:
             dockerfile: ./Dockerfile
+        command: bash -c "sleep 3; python -u main.py"
         depends_on:
             lavalink:
                 condition: service_started


### PR DESCRIPTION
When using Docker compose,
```yml
depends_on:
    lavalink:
        condition: service_started
```
is sometimes not enough since Lavalink takes a few seconds to properly finish initializing and ready to accept connections.

The correct approach would be
```yml
depends_on:
    lavalink:
        condition: service_healthy
```
if `lavalink` had a health check.

Another option would be to crash/stop/fail the `vocard` container as soon as its unable to connect to a Node. That way one could also use
```yml
vocard:
    restart: unless-stopped
```
and the container would just keep restarting until a proper connection was made.

Overall, I still believe setting a hard coded wait is the best and most simple option.