### PR TITLE
Adding channelId to update to Lavalink 4.2's Voice State

### DIFF
--- a/voicelink/player.py
+++ b/voicelink/player.py
@@ -343,6 +343,7 @@ class Player(VoiceProtocol):
             "token": state['event']['token'],
             "endpoint": state['event']['endpoint'],
             "sessionId": state['sessionId'],
+            "channelId": state['channel_id'],
         }
         
         await self.send(method=RequestMethod.PATCH, data={"voice": data})


### PR DESCRIPTION
February 28, 2026 - LavaLink v4.2.1

Voice State
| Field     | Type      | Description |
|-----------|-----------|-------------|
| token     | string    | Discord voice token |
| endpoint  | string    | Discord voice endpoint |
| sessionId | string    | Discord voice session ID |
| **channelId** | **?string** | **Discord voice channel ID the bot is connecting to** |
