### PR TITLE
fix: implement persistent volume across sessions and song transitions

### DIFF
--- a/cogs/settings.py
+++ b/cogs/settings.py
@@ -184,8 +184,9 @@ class Settings(commands.Cog, name="settings"):
         player: voicelink.Player = ctx.guild.voice_client
         if player:
             await player.set_volume(value, ctx.author)
+        else:
+            await update_settings(ctx.guild.id, {"$set": {'volume': value}})
 
-        await update_settings(ctx.guild.id, {"$set": {'volume': value}})
         await send(ctx, 'setVolume', value)
 
     @settings.command(name="togglecontroller", aliases=get_aliases("togglecontroller"))

--- a/ipc/methods.py
+++ b/ipc/methods.py
@@ -274,7 +274,6 @@ async def clearQueue(player: Player, member: Member, data: Dict) -> None:
 @require_permission(only_admin=True)
 async def updateVolume(player: Player, member: Member, data: Dict) -> None:
     volume = data.get("volume", 100)
-    await func.update_settings(player.guild.id, {"$set": {"volume": volume}})
     await player.set_volume(volume=volume, requester=member)
 
 async def updatePause(player: Player, member: Member, data: Dict) -> None:

--- a/voicelink/player.py
+++ b/voicelink/player.py
@@ -693,9 +693,12 @@ class Player(VoiceProtocol):
     async def set_volume(self, volume: int, requester: Member = None) -> int:
         """Sets the volume of the player as an integer. Lavalink accepts values from 0 to 500."""
         await self.send(method=RequestMethod.PATCH, data={"volume": volume})
+
+        if self._volume != volume:
+            self.settings['volume'] = volume
+            await func.update_settings(self.guild.id, {"$set": {"volume": volume}})
+
         self._volume = volume
-        self.settings['volume'] = volume
-        await func.update_settings(self.guild.id, {"$set": {"volume": volume}})
 
         if self.is_ipc_connected:
             await self.send_ws({"op": "updateVolume", "volume": volume}, requester)

--- a/voicelink/player.py
+++ b/voicelink/player.py
@@ -73,9 +73,6 @@ async def connect_channel(ctx: Union[commands.Context, Interaction], channel: Vo
             channel, ctx, settings
         ))
 
-    if player.volume != 100:
-        await player.set_volume(player.volume)
-
     if ctx.bot.ipc.is_connected:
         await player.send_ws({"op": "createPlayer", "memberIds": [str(member.id) for member in channel.members]})
 
@@ -343,6 +340,7 @@ class Player(VoiceProtocol):
             "token": state['event']['token'],
             "endpoint": state['event']['endpoint'],
             "sessionId": state['sessionId'],
+            "channelId": str(self.channel.id),
         }
         
         await self.send(method=RequestMethod.PATCH, data={"voice": data})
@@ -541,6 +539,8 @@ class Player(VoiceProtocol):
 
         if self.channel:
             self._logger.debug(f"Player in {self.guild.name}({self.guild.id}) has been connected to {self.channel.name}({self.channel.id}).")
+        
+        await self.set_volume(self._volume)
             
     async def stop(self):
         """Stops the currently playing track."""
@@ -694,6 +694,8 @@ class Player(VoiceProtocol):
         """Sets the volume of the player as an integer. Lavalink accepts values from 0 to 500."""
         await self.send(method=RequestMethod.PATCH, data={"volume": volume})
         self._volume = volume
+        self.settings['volume'] = volume
+        await func.update_settings(self.guild.id, {"$set": {"volume": volume}})
 
         if self.is_ipc_connected:
             await self.send_ws({"op": "updateVolume", "volume": volume}, requester)

--- a/voicelink/pool.py
+++ b/voicelink/pool.py
@@ -325,6 +325,7 @@ class Node:
                     await player._dispatch_voice_update(player._voice_state)
 
                 if player.current:
+                    await player.set_volume(player.volume)
                     await player.play(track=player.current, start=min(player._last_position, player.current.length))
 
                     if player.is_paused:


### PR DESCRIPTION
This commit ensures that the volume setting is saved to the database upon change and correctly applied whenever a player connects or restores a session. It also includes a fix for channelId in voice updates to improve session stability.