### PR TITLE
Retry Lavalink node connections on startup

### DIFF
--- a/cogs/listeners.py
+++ b/cogs/listeners.py
@@ -43,27 +43,46 @@ class Listeners(commands.Cog):
         bot.loop.create_task(self.restore_last_session_players())
         
     async def start_nodes(self) -> None:
-        """Connect and intiate nodes with retry."""
+        """Connect and initiate nodes."""
         nodes = list(Config().nodes.values())
         max_retries = 12
 
         for attempt in range(max_retries):
             for n in nodes:
-                # Skip already connected nodes
-                if n["identifier"] in self.voicelink._nodes:
+                n_id = n["identifier"]
+
+                # TryOnce nodes skip all retries (pass 0 only)
+                if n.get("reconnect_strategy", "TryOnce") != "ReconnectOnDrop" and attempt > 0:
                     continue
+
+                # Skip nodes that are already connected
+                if n_id in self.voicelink._nodes:
+                    continue
+
                 try:
                     await self.voicelink.create_node(bot=self.bot, **n)
-                    func.logger.info(f'Node {n["identifier"]} connected successfully.')
+                    func.logger.info(f'Node {n_id} connected successfully.')
                 except Exception as e:
-                    func.logger.error(f'Node {n["identifier"]} is not able to connect! - Reason: {e}')
+                    func.logger.error(f'Node {n_id} is not able to connect! - Reason: {e}')
 
+            # Check if all nodes are connected after this pass
             if len(self.voicelink._nodes) == len(nodes):
                 func.logger.info("All nodes connected successfully.")
                 return
 
+            # Count remaining ReconnectOnDrop nodes
+            num_remaining = len([
+                n for n in nodes
+                if n["identifier"] not in self.voicelink._nodes
+                and n.get("reconnect_strategy", "TryOnce") == "ReconnectOnDrop"
+            ])
+
+            # No retryable nodes left
+            if num_remaining == 0:
+                return
+
             if attempt < max_retries - 1:
-                func.logger.info(f"Retrying nodes in 5s ({attempt + 1}/{max_retries})...")
+                func.logger.info(f"Retrying {num_remaining} node(s) in 5s ({attempt + 1}/{max_retries})...")
                 await asyncio.sleep(5)
 
         func.logger.warning(f"Some nodes failed to connect after {max_retries} attempts.")

--- a/cogs/listeners.py
+++ b/cogs/listeners.py
@@ -47,7 +47,6 @@ class Listeners(commands.Cog):
         for n in Config().nodes.values():
             try:
                 await self.voicelink.create_node(bot=self.bot, **n)
-                func.logger.info(f'Node {n["identifier"]} connected successfully.')
             except Exception as e:
                 func.logger.error(f'Node {n["identifier"]} is not able to connect! - Reason: {e}')
 

--- a/cogs/listeners.py
+++ b/cogs/listeners.py
@@ -43,12 +43,30 @@ class Listeners(commands.Cog):
         bot.loop.create_task(self.restore_last_session_players())
         
     async def start_nodes(self) -> None:
-        """Connect and intiate nodes."""
-        for n in Config().nodes.values():
-            try:
-                await self.voicelink.create_node(bot=self.bot, **n)
-            except Exception as e:
-                func.logger.error(f'Node {n["identifier"]} is not able to connect! - Reason: {e}')
+        """Connect and intiate nodes with retry."""
+        nodes = list(Config().nodes.values())
+        max_retries = 12
+
+        for attempt in range(max_retries):
+            for n in nodes:
+                # Skip already connected nodes
+                if n["identifier"] in self.voicelink._nodes:
+                    continue
+                try:
+                    await self.voicelink.create_node(bot=self.bot, **n)
+                    func.logger.info(f'Node {n["identifier"]} connected successfully.')
+                except Exception as e:
+                    func.logger.error(f'Node {n["identifier"]} is not able to connect! - Reason: {e}')
+
+            if len(self.voicelink._nodes) == len(nodes):
+                func.logger.info("All nodes connected successfully.")
+                return
+
+            if attempt < max_retries - 1:
+                func.logger.info(f"Retrying nodes in 5s ({attempt + 1}/{max_retries})...")
+                await asyncio.sleep(5)
+
+        func.logger.warning(f"Some nodes failed to connect after {max_retries} attempts.")
 
     async def restore_last_session_players(self) -> None:
         """Re-establish connections for players from the last session."""

--- a/cogs/listeners.py
+++ b/cogs/listeners.py
@@ -44,48 +44,12 @@ class Listeners(commands.Cog):
         
     async def start_nodes(self) -> None:
         """Connect and initiate nodes."""
-        nodes = list(Config().nodes.values())
-        max_retries = 12
-
-        for attempt in range(max_retries):
-            for n in nodes:
-                n_id = n["identifier"]
-
-                # TryOnce nodes skip all retries (pass 0 only)
-                if n.get("reconnect_strategy", "TryOnce") != "ReconnectOnDrop" and attempt > 0:
-                    continue
-
-                # Skip nodes that are already connected
-                if n_id in self.voicelink._nodes:
-                    continue
-
-                try:
-                    await self.voicelink.create_node(bot=self.bot, **n)
-                    func.logger.info(f'Node {n_id} connected successfully.')
-                except Exception as e:
-                    func.logger.error(f'Node {n_id} is not able to connect! - Reason: {e}')
-
-            # Check if all nodes are connected after this pass
-            if len(self.voicelink._nodes) == len(nodes):
-                func.logger.info("All nodes connected successfully.")
-                return
-
-            # Count remaining ReconnectOnDrop nodes
-            num_remaining = len([
-                n for n in nodes
-                if n["identifier"] not in self.voicelink._nodes
-                and n.get("reconnect_strategy", "TryOnce") == "ReconnectOnDrop"
-            ])
-
-            # No retryable nodes left
-            if num_remaining == 0:
-                return
-
-            if attempt < max_retries - 1:
-                func.logger.info(f"Retrying {num_remaining} node(s) in 5s ({attempt + 1}/{max_retries})...")
-                await asyncio.sleep(5)
-
-        func.logger.warning(f"Some nodes failed to connect after {max_retries} attempts.")
+        for n in Config().nodes.values():
+            try:
+                await self.voicelink.create_node(bot=self.bot, **n)
+                func.logger.info(f'Node {n["identifier"]} connected successfully.')
+            except Exception as e:
+                func.logger.error(f'Node {n["identifier"]} is not able to connect! - Reason: {e}')
 
     async def restore_last_session_players(self) -> None:
         """Re-establish connections for players from the last session."""

--- a/settings Example.json
+++ b/settings Example.json
@@ -11,6 +11,7 @@
             "password": "youshallnotpass",
             "secure": false,
             "identifier": "DEFAULT",
+            "reconnect_strategy": "ReconnectOnDrop",
             "yt_ratelimit": {
                 "tokens": [],
                 "config": {

--- a/voicelink/__init__.py
+++ b/voicelink/__init__.py
@@ -27,7 +27,7 @@ __license__ = "MIT"
 __copyright__ = "Copyright 2023 - present (c) Vocard Development, ChocoMeow"
 
 from .config import Config
-from .enums import SearchType, LoopType, TrackRecType
+from .enums import SearchType, LoopType, TrackRecType, ReconnectStrategy
 from .events import *
 from .exceptions import *
 from .filters import *

--- a/voicelink/enums.py
+++ b/voicelink/enums.py
@@ -214,3 +214,52 @@ class NodeAlgorithm(Enum):
 
     def __str__(self) -> str:
         return self.value
+
+class ReconnectStrategy(Enum):
+    """The enum for Lavalink node connection retry strategies.
+
+        ReconnectStrategy.TRY_ONCE:
+          Connect once on startup. Do not reconnect if the connection drops.
+
+        ReconnectStrategy.RETRY_ON_STARTUP:
+          Retry failed startup connections (limited). Do not reconnect on drop.
+
+        ReconnectStrategy.RECONNECT_ON_DROP:
+          Retry failed startup connections (limited) and reconnect if the
+          websocket drops.
+
+        ReconnectStrategy.ALWAYS:
+          Keep retrying forever on startup and on websocket drop.
+    """
+
+    TRY_ONCE = "TryOnce"
+    RETRY_ON_STARTUP = "RetryOnStartup"
+    RECONNECT_ON_DROP = "ReconnectOnDrop"
+    ALWAYS = "Always"
+
+    def __str__(self) -> str:
+        return self.value
+
+    @property
+    def reconnect_on_drop(self) -> bool:
+        return self in (ReconnectStrategy.RECONNECT_ON_DROP, ReconnectStrategy.ALWAYS)
+
+    @property
+    def max_startup_retries(self):
+        """Max startup attempts. ``None`` means retry forever."""
+        if self == ReconnectStrategy.TRY_ONCE:
+            return 1
+        if self == ReconnectStrategy.ALWAYS:
+            return None
+        return 12  # RETRY_ON_STARTUP, RECONNECT_ON_DROP
+
+    @classmethod
+    def from_value(cls, value: str = None) -> "ReconnectStrategy":
+        if isinstance(value, cls):
+            return value
+        if not value:
+            return cls.TRY_ONCE
+        for member in cls:
+            if member.value.lower() == value.lower() or member.name.lower() == value.lower():
+                return member
+        return cls.TRY_ONCE

--- a/voicelink/pool.py
+++ b/voicelink/pool.py
@@ -38,7 +38,7 @@ from . import (
     __version__
 )
 
-from .enums import SearchType, NodeAlgorithm
+from .enums import SearchType, NodeAlgorithm, RequestMethod, ReconnectStrategy
 from .exceptions import (
     NodeConnectionFailure,
     NodeCreationError,
@@ -49,7 +49,6 @@ from .exceptions import (
 )
 from .objects import Playlist, Track
 from .utils import ExponentialBackoff, NodeStats, NodeInfo, Ping
-from .enums import RequestMethod
 from .ratelimit import YTRatelimit, YTToken, STRATEGY
 from .config import Config
 
@@ -81,7 +80,8 @@ class Node:
         yt_ratelimit: dict = None,
         session: Optional[aiohttp.ClientSession] = None,
         resume_key: Optional[str] = None,
-        logger: Optional[logging.Logger] = None
+        logger: Optional[logging.Logger] = None,
+        reconnect_strategy: ReconnectStrategy = ReconnectStrategy.TRY_ONCE
     ):
         self._bot: Bot = bot
         self._host: str = host
@@ -93,6 +93,7 @@ class Node:
         self._secure: bool = secure
         self._logger: Optional[logging.Logger] = logger
         self._stats: Optional[NodeStats] = None
+        self._reconnect_strategy: ReconnectStrategy = reconnect_strategy
 
         self._websocket_uri: str = f"{'wss' if self._secure else 'ws'}://{self._host}:{self._port}/" + NODE_VERSION + "/websocket"
         self._rest_uri: str = f"{'https' if self._secure else 'http'}://{self._host}:{self._port}"
@@ -219,6 +220,13 @@ class Node:
                 break
 
         while not self._available:
+            if not self._reconnect_strategy.reconnect_on_drop:
+                self._logger.warning(
+                    f"Node [{self._identifier}] disconnected. "
+                    f"Reconnect strategy is {self._reconnect_strategy}, not reconnecting."
+                )
+                return
+
             retry = backoff.delay()
             self._logger.info(f"Trying to reconnect node [{self._identifier}] in {round(retry)}s")
             await asyncio.sleep(retry)
@@ -485,7 +493,8 @@ class NodePool:
         yt_ratelimit: dict = None,
         session: Optional[aiohttp.ClientSession] = None,
         resume_key: Optional[str] = None,
-        logger: Optional[logging.Logger] = None
+        logger: Optional[logging.Logger] = None,
+        reconnect_strategy: Union[str, ReconnectStrategy] = ReconnectStrategy.RECONNECT_ON_DROP
     ) -> Node:
         """Creates a Node object to be then added into the node pool.
         """
@@ -494,13 +503,36 @@ class NodePool:
         
         if not logger:
             logger = logging.getLogger("vocard")
-            
+
+        strategy = ReconnectStrategy.from_value(reconnect_strategy)
+        max_retries = strategy.max_startup_retries
+        backoff = ExponentialBackoff(base=7) if max_retries != 1 else None
+
         node = Node(
             pool=cls, bot=bot, host=host, port=port, password=password,
             identifier=identifier, secure=secure, heartbeat=heartbeat, yt_ratelimit=yt_ratelimit,
-            session=session, resume_key=resume_key, logger=logger
+            session=session, resume_key=resume_key, logger=logger, reconnect_strategy=strategy
         )
 
-        await node.connect()
-        cls._nodes[node._identifier] = node
-        return node
+        attempt = 0
+        last_error: Exception = None
+        while True:
+            attempt += 1
+            try:
+                await node.connect()
+                cls._nodes[node._identifier] = node
+                return node
+            except Exception as e:
+                last_error = e
+                if max_retries is not None and attempt >= max_retries:
+                    break
+
+                retry = backoff.delay()
+                retries_label = "inf" if max_retries is None else str(max_retries)
+                logger.warning(
+                    f"Node [{identifier}] failed to connect ({attempt}/{retries_label}): {e}. "
+                    f"Retrying in {round(retry)}s..."
+                )
+                await asyncio.sleep(retry)
+
+        raise last_error


### PR DESCRIPTION
If Lavalink isnt fully ready when Vocard starts (common in Docker where healthchecks have a brief race window), `start_nodes()` tries each node once and silently gives up, leaving the bot with zero nodes and the user seeing "There are no nodes available."

Every 5s for up to 12 attempts (1 minute) so the bot recovers from a delayed Lavalink startup. Already connected nodes are skipped via `self.voicelink._nodes` check.

Addresses https://github.com/ChocoMeow/Vocard/issues/125